### PR TITLE
Reverting change that breaks export-all 

### DIFF
--- a/mlflow_export_import/bulk/bulk_utils.py
+++ b/mlflow_export_import/bulk/bulk_utils.py
@@ -8,6 +8,7 @@ def get_experiment_ids(experiment_ids):
     """
     Return a list experiment IDS
     """
+
     if isinstance(experiment_ids,str):
         if experiment_ids == "all":
             return [ exp.experiment_id for exp in client.list_experiments() ]
@@ -18,5 +19,8 @@ def get_experiment_ids(experiment_ids):
             return experiment_ids.split(",")
     elif isinstance(experiment_ids,list):
         return experiment_ids
+    elif isinstance(experiment_ids,dict):
+        experiment_ids = list(experiment_ids.keys())
+        return experiment_ids
     else:
-        raise MlflowExportImportException(f"Argument to get_experiment_ids() is of type '{type(experiment_ids)}. Must must be a string or list")
+        raise MlflowExportImportException(f"Argument to get_experiment_ids() is of type '{type(experiment_ids)}. Must must be a string, list or dict")

--- a/mlflow_export_import/bulk/export_experiments.py
+++ b/mlflow_export_import/bulk/export_experiments.py
@@ -49,20 +49,18 @@ def export_experiments(experiments, output_dir, export_metadata_tags, notebook_f
     start_time = time.time()
     max_workers = os.cpu_count() or 4 if use_threads else 1
 
-    export_all_runs = not isinstance(experiments,dict) 
+    export_all_runs = not isinstance(experiments,dict)
     if export_all_runs:
-        experiments = list(experiments)
         experiments = bulk_utils.get_experiment_ids(experiments)
         table_data = experiments
         columns = ["Experiment Name or ID"]
         experiments_dct = {}
     else:
         experiments_dct = experiments
-        experiments = list(experiments.keys())
         experiments = bulk_utils.get_experiment_ids(experiments)
-        table_data = [ [exp_id,len(runs)] for exp_id,runs in experiments_dct.items() ]
+        table_data = [[exp_id, len(runs)] for exp_id, runs in experiments_dct.items()]
         num_runs = sum(x[1] for x in table_data)
-        table_data.append(["Total",num_runs])
+        table_data.append(["Total", num_runs])
         columns = ["Experiment ID", "# Runs"]
     utils.show_table("Experiments",table_data,columns)
     print("")

--- a/mlflow_export_import/bulk/export_models.py
+++ b/mlflow_export_import/bulk/export_models.py
@@ -71,7 +71,7 @@ def _export_models(models, output_dir, notebook_formats, stages, export_run=True
 
 def export_models(models, output_dir, notebook_formats, stages="", export_all_runs=False, use_threads=False):
     exps_and_runs = get_experiments_runs_of_models(models)
-    exp_ids = exps_and_runs.keys()
+    exp_ids = list(exps_and_runs.keys())
     start_time = time.time()
     out_dir = os.path.join(output_dir,"experiments")
     exps_to_export = exp_ids if export_all_runs else exps_and_runs


### PR DESCRIPTION
- reverting changes made to export_expriments and move them to get_experiment_ids. 
- Make exp_ids a list when exporting all runs

Fixes:
```
> export-all --output-dir out
MLflow Version: 1.24.0
MLflow Tracking URI: http://localhost:8080
Options:
  output_dir: out
  notebook_formats:
  use_threads: False
Experiments
+-------------------------+
| Experiment Name or ID   |
|-------------------------|
| a                       |
| l                       |
| l                       |
+-------------------------+

Databricks REST client: http://localhost:8080/api/2.0
```